### PR TITLE
Expressing releases using weak until

### DIFF
--- a/include/copycat/ltl.hpp
+++ b/include/copycat/ltl.hpp
@@ -152,6 +152,8 @@ namespace copycat
 class ltl_formula_store
 {
 public:
+  class ltl_operators;
+
   using node = uint32_t;
 
   struct ltl_formula
@@ -316,11 +318,6 @@ public:
     return {index,0};
   }
 
-  ltl_formula create_and( ltl_formula const& a, ltl_formula const& b )
-  {
-      return !create_or( !a, !b );
-  }
-
   ltl_formula create_next( ltl_formula const& a )
   {
     /* trivial cases */
@@ -441,36 +438,10 @@ public:
     return {index,0};
   }
 
-  ltl_formula eventually( ltl_formula const &a )
-  {
-    /* F(a) = (true)U(a) */
-    return create_until( get_constant( true ), a );
-  }
-
   ltl_formula create_globally( ltl_formula const& a )
   {
     /* G(a) = !F(!(a)) */
     return !create_eventually( !a );
-  }
-
-  ltl_formula globally( ltl_formula const& a )
-  {
-    /* G(a) = !F(!(a)) */
-    return !eventually( !a );
-  }
-
-  ltl_formula weak_until( ltl_formula const& a, ltl_formula const& b )
-  {
-    /* (a)W(b) = ((a)U(b))|G(a) */
-    const auto until = create_until( a, b );
-    const auto globally = create_globally( a );
-    return create_or( until, globally );
-  }
-
-  ltl_formula releases( ltl_formula const& a, ltl_formula const& b )
-  {
-    /* (a)R(b) = !((!a)U(!b)) */
-    return !create_until( !a, !b );
   }
 
   bool is_constant( node const& n ) const

--- a/include/copycat/ltl.hpp
+++ b/include/copycat/ltl.hpp
@@ -316,6 +316,11 @@ public:
     return {index,0};
   }
 
+  ltl_formula create_and( ltl_formula const& a, ltl_formula const& b )
+  {
+      return !create_or(!a, !b);
+  }
+
   ltl_formula create_next( ltl_formula const& a )
   {
     /* trivial cases */
@@ -355,33 +360,6 @@ public:
     n.children[0] = a;
     n.children[1] = b;
     n.data[0] = ltl_operator::Until;
-    n.data[1] = 0;
-
-    const auto it = storage->hash.find( n );
-    if ( it != std::end( storage->hash ) )
-    {
-      return {it->second, 0};
-    }
-
-    const auto index = node( storage->nodes.size() );
-    if ( index >= .9 * storage->nodes.capacity() )
-    {
-      storage->nodes.reserve( uint32_t( 3.1415f * index ) );
-      storage->hash.reserve( uint32_t( 3.1415f * index ) );
-    }
-
-    storage->nodes.push_back( n );
-    storage->hash[n] = index;
-
-    return {index,0};
-  }
-
-  ltl_formula create_releases( ltl_formula const& a, ltl_formula const& b )
-  {
-    ltl_storage::node_type n;
-    n.children[0] = a;
-    n.children[1] = b;
-    n.data[0] = ltl_operator::Releases;
     n.data[1] = 0;
 
     const auto it = storage->hash.find( n );
@@ -452,6 +430,20 @@ public:
   {
     /* G(a) = !F(!(a)) */
     return !eventually( !a );
+  }
+
+  ltl_formula create_weak_until( ltl_formula const& a, ltl_formula const& b )
+  {
+    /* (a)W(b) = ((a)U(b))|G(a) */
+    auto until = create_until(a, b);
+    auto globally = create_globally(a);
+    return create_or(until, globally);
+  }
+
+  ltl_formula create_releases( ltl_formula const& a, ltl_formula const& b )
+  {
+    /* (a)R(b) = (b)W((a)&(b)) */
+    return create_weak_until(b, create_and(a, b));
   }
 
   bool is_constant( node const& n ) const

--- a/include/copycat/utils/ltl_operators.hpp
+++ b/include/copycat/utils/ltl_operators.hpp
@@ -1,0 +1,80 @@
+/* copycat
+ * Copyright (C) 2018  EPFL
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file ltl_operators.hpp
+  \brief LTL syntactic sugar for creation of new nodes
+
+  \author Gianluca Martino
+*/
+
+#pragma once
+
+#include <copycat/ltl.hpp>
+
+namespace copycat
+{
+
+class ltl_formula_store::ltl_operators
+{
+public:
+  explicit ltl_operators( ltl_formula_store& s ) : storage( s )
+  {
+  }
+
+  ltl_formula make_and( ltl_formula const& a, ltl_formula const& b )
+  {
+    return !storage.create_or( !a, !b );
+  }
+
+  ltl_formula eventually( ltl_formula const& a )
+  {
+    /* F(a) = (true)U(a) */
+    return storage.create_until( storage.get_constant( true ), a );
+  }
+
+  ltl_formula globally( ltl_formula const& a )
+  {
+    /* G(a) = !F(!(a)) */
+    return !eventually( !a );
+  }
+
+  ltl_formula weak_until( ltl_formula const& a, ltl_formula const& b )
+  {
+    /* (a)W(b) = ((a)U(b))|G(a) */
+    const auto until = storage.create_until( a, b );
+    const auto globally = storage.create_globally( a );
+    return storage.create_or( until, globally );
+  }
+
+  ltl_formula releases( ltl_formula const& a, ltl_formula const& b )
+  {
+    /* (a)R(b) = !((!a)U(!b)) */
+    return !storage.create_until( !a, !b );
+  }
+
+  ltl_formula_store& storage;
+};
+}


### PR DESCRIPTION
I added the method create_weak_until (and create_and for readability purposes) in order to express the release operator using the weak until:

(a)R(b) = (b)W((a)&(b))